### PR TITLE
http input bug fix: windows buf not null term

### DIFF
--- a/src/ngx_aggr_window.c
+++ b/src/ngx_aggr_window.c
@@ -345,11 +345,13 @@ ngx_aggr_window_get_recv_buf(ngx_aggr_window_t *window,
     }
 
     buf = window->buf;
-    if (buf != NULL &&
-        (size_t) (buf->end - buf->last) > window->conf.recv_size)
-    {
-        *result = buf;
-        return NGX_OK;
+    if (buf != NULL) {
+        if ((size_t) (buf->end - buf->last) > window->conf.recv_size) {
+            *result = buf;
+            return NGX_OK;
+        }
+
+        *buf->last = '\0';
     }
 
     ngx_spinlock(&window->lock, 1, 2048);
@@ -378,8 +380,8 @@ ngx_aggr_window_get_recv_buf(ngx_aggr_window_t *window,
             return NGX_ERROR;
         }
 
-        buf->start = (void *)(buf + 1);
-        buf->end = buf->start + window->conf.buf_size;
+        buf->start = (void *) (buf + 1);
+        buf->end = buf->start + window->conf.buf_size - 1;  /* room for null */
     }
 
     buf->last = buf->start;

--- a/src/ngx_dgram_aggr_module.c
+++ b/src/ngx_dgram_aggr_module.c
@@ -159,7 +159,7 @@ ngx_dgram_aggr_input_handler(ngx_dgram_session_t *s)
 
         recv_buf = buf->last;
 
-        n = ngx_dgram_recv(c, recv_buf, buf->end - buf->last - 1);
+        n = ngx_dgram_recv(c, recv_buf, buf->end - buf->last);
         if (n <= 0) {
             switch (n) {
 


### PR DESCRIPTION
ngx_aggr_window_write fills the buffer completely, the buffer is not
necessarily null term. when the event is later parsed, random memory
content may be read.