### PR TITLE
http-input: hung requests bug fix

### DIFF
--- a/src/ngx_aggr_map_ip2l.c
+++ b/src/ngx_aggr_map_ip2l.c
@@ -213,26 +213,26 @@ ngx_aggr_map_ip2l_json(ngx_aggr_query_init_t *init, ngx_str_t *output,
         }
 
         ngx_log_error(NGX_LOG_ERR, init->pool->log, 0,
-            "ngx_aggr_map_json: invalid parameter \"%V\"",
+            "ngx_aggr_map_ip2l_json: invalid parameter \"%V\"",
             &elts[i].key);
         return NGX_BAD_QUERY;
     }
 
     if (input == NULL) {
         ngx_log_error(NGX_LOG_ERR, init->pool->log, 0,
-            "ngx_aggr_map_json: missing \"input\" key");
+            "ngx_aggr_map_ip2l_json: missing \"input\" key");
         return NGX_BAD_QUERY;
     }
 
     if (file == NULL) {
         ngx_log_error(NGX_LOG_ERR, init->pool->log, 0,
-            "ngx_aggr_map_json: missing \"file\" key");
+            "ngx_aggr_map_ip2l_json: missing \"file\" key");
         return NGX_BAD_QUERY;
     }
 
     if (field == NULL) {
         ngx_log_error(NGX_LOG_ERR, init->pool->log, 0,
-            "ngx_aggr_map_json: missing \"field\" key");
+            "ngx_aggr_map_ip2l_json: missing \"field\" key");
         return NGX_BAD_QUERY;
     }
 

--- a/src/ngx_aggr_map_metric.c
+++ b/src/ngx_aggr_map_metric.c
@@ -175,7 +175,7 @@ ngx_aggr_map_range(ngx_pool_t *pool, ngx_str_t *input,
     p = ngx_strlchr(input->data, last, ':');
     if (p == NULL) {
         ngx_log_error(NGX_LOG_ERR, pool->log, 0,
-            "ngx_aggr_map_metric_add_value: "
+            "ngx_aggr_map_range: "
             "invalid range \"%V\", missing ':'", input);
         return NGX_BAD_QUERY;
     }
@@ -202,7 +202,7 @@ ngx_aggr_map_range(ngx_pool_t *pool, ngx_str_t *input,
 
     if (elt->min >= elt->max) {
         ngx_log_error(NGX_LOG_ERR, pool->log, 0,
-            "ngx_aggr_map_metric_add_value: "
+            "ngx_aggr_map_range: "
             "invalid range \"%V\", lower bound must be less than upper",
             input);
         return NGX_BAD_QUERY;

--- a/src/ngx_http_aggr_input_module.c
+++ b/src/ngx_http_aggr_input_module.c
@@ -354,7 +354,7 @@ append:
 
 
 static ngx_int_t
-ngx_http_aggr_input_do_process(ngx_http_request_t *r, ngx_uint_t do_read)
+ngx_http_aggr_input_do_process(ngx_http_request_t *r)
 {
     ngx_int_t     rc;
     ngx_buf_t    *b;
@@ -389,10 +389,6 @@ ngx_http_aggr_input_do_process(ngx_http_request_t *r, ngx_uint_t do_read)
             ngx_free_chain(r->pool, ln);
         }
 
-        if (!do_read) {
-            return NGX_AGAIN;
-        }
-
         rc = ngx_http_read_unbuffered_request_body(r);
 
         if (rc >= NGX_HTTP_SPECIAL_RESPONSE) {
@@ -417,7 +413,7 @@ ngx_http_aggr_input_read_handler(ngx_http_request_t *r)
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
         "ngx_http_aggr_input_read_handler: called");
 
-    rc = ngx_http_aggr_input_do_process(r, 1);
+    rc = ngx_http_aggr_input_do_process(r);
     if (rc == NGX_AGAIN) {
         return;
     }
@@ -458,12 +454,12 @@ ngx_http_aggr_input_handler(ngx_http_request_t *r)
 
     if (r->request_body == NULL) {
         ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
-            "ngx_http_aggr_input_client_body_handler: "
+            "ngx_http_aggr_input_handler: "
             "%V request body is unavailable", &r->method_name);
         rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
 
     } else {
-        rc = ngx_http_aggr_input_do_process(r, 0);
+        rc = ngx_http_aggr_input_do_process(r);
     }
 
     if (rc != NGX_AGAIN) {


### PR DESCRIPTION
must call ngx_http_read_unbuffered_request_body also in the first
processing cycle. the request body buffer may have already been filled,
causing ngx_http_read_client_request_body to stop reading from the
connection. if this happens, the request will hang until the client
disconnects. reading the body after pulling the buffers prevents it.